### PR TITLE
Add login session storage using tokens

### DIFF
--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -24,27 +24,13 @@ return [
             'from'    => ''
         ],
     ],
-    'environments' => [
-        'systems' => [
-
+    'environment' => [
+        'emailOverride' => [
+            'enabled' => false,
+            'recipient' => []
         ],
-        'development' => [
-            'emailOverride' => [
-                'enabled' => true,
-                'recipients' => [],
-            ],
-            'timeoutWarningThreshold' => 5, // Minutes
-            'activeSessionCheck' => true,
-            'passwordOverride' => 'dillydilly',
-        ],
-        'production' => [
-            'email_override' => [
-                'enabled' => false,
-                'recipient' => []
-            ],
-            'timeoutWarningThreshold' => 5, // Minutes
-            'activeSessionCheck' => true,
-        ],
+        'timeoutWarningThreshold' => 5, // Minutes
+        'activeSessionCheck' => true,
     ],
     'noTokenRequired' => [
         'api.rpc.login' => 'Login API Controller',

--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -26,11 +26,11 @@ return [
     ],
     'environment' => [
         'emailOverride' => [
-            'enabled' => false,
+            'enabled'   => false,
             'recipient' => []
         ],
         'timeoutWarningThreshold' => 5, // Minutes
-        'activeSessionCheck' => true,
+        'activeSessionCheck'      => true,
     ],
     'noTokenRequired' => [
         'api.rpc.login' => 'Login API Controller',

--- a/module/API/src/V1/Rpc/CheckSessionStatus/CheckSessionStatusController.php
+++ b/module/API/src/V1/Rpc/CheckSessionStatus/CheckSessionStatusController.php
@@ -82,7 +82,7 @@ class CheckSessionStatusController extends AbstractActionController
 
     private function executeService(): void
     {
-        $this->userTokenSession = $this->authenticateStorageService->getTokenSession($this->tokenVO);
+        $this->userTokenSession = $this->authenticateStorageService->getUserSessionByToken($this->tokenVO);
     }
 
     private function prepareReturnData(): void

--- a/module/EyeChart/src/DAO/AbstractDAO.php
+++ b/module/EyeChart/src/DAO/AbstractDAO.php
@@ -11,6 +11,7 @@ namespace EyeChart\DAO;
 use Zend\Db\Adapter\Adapter;
 use Zend\Db\Adapter\Driver\ResultInterface;
 use Zend\Db\ResultSet\ResultSet;
+use Zend\Db\Sql\AbstractPreparableSql;
 use Zend\Db\Sql\Select;
 use Zend\Db\Sql\Sql;
 
@@ -43,9 +44,7 @@ class AbstractDAO
         $returnType = ResultSet::TYPE_ARRAYOBJECT,
         $arrayObjectPrototype = null
     ) {
-        $statement = $this->getSqlAdapter()->prepareStatementForSqlObject($select);
-
-        $result = $statement->execute();
+        $result = $this->executeStatement($select);
 
         if ($result instanceof ResultInterface && $result->isQueryResult()) {
             $resultSet = new ResultSet($returnType, $arrayObjectPrototype);
@@ -67,5 +66,16 @@ class AbstractDAO
     protected function getSqlAdapter(): Sql
     {
         return $this->sql;
+    }
+
+    /**
+     * @param AbstractPreparableSql $sql
+     * @return ResultInterface
+     */
+    protected function executeStatement(AbstractPreparableSql $sql): ResultInterface
+    {
+        $statement = $this->getSqlAdapter()->prepareStatementForSqlObject($sql);
+
+        return $statement->execute();
     }
 }

--- a/module/EyeChart/src/DAO/Authenticate/AuthenticateDAO.php
+++ b/module/EyeChart/src/DAO/Authenticate/AuthenticateDAO.php
@@ -42,6 +42,6 @@ class AuthenticateDAO extends AbstractDAO
 
         $result = parent::getResultSingleResult($select, ResultSet::TYPE_ARRAY);
 
-        return (! is_null($result));
+        return (!is_null($result));
     }
 }

--- a/module/EyeChart/src/DAO/Authenticate/AuthenticateStorageDAO.php
+++ b/module/EyeChart/src/DAO/Authenticate/AuthenticateStorageDAO.php
@@ -97,7 +97,32 @@ final class AuthenticateStorageDAO extends AbstractDAO implements StorageInterfa
             throw new MissingSessionException($this->sessionEntity, __METHOD__);
         }
 
-        return $result;
+        return $this->parseDataTypes($result->getArrayCopy());
+    }
+
+    /**
+     * This is not a good solution.  But until we can find a way for the data to return in the proper types, this will
+     * have to do.
+     *
+     * @param mixed[] $record
+     * @return mixed[]
+     */
+    private function parseDataTypes(array $record): array
+    {
+        foreach ($record as $key => $value) {
+            switch (true) {
+                case (strpos($value, '.') === true) :
+                    $record[$key] = (float)$value;
+
+                    break;
+                case (is_numeric($value)) :
+                    $record[$key] = (int)$value;
+
+                default:
+            }
+        }
+
+        return $record;
     }
 
     /**

--- a/module/EyeChart/src/DAO/Authenticate/AuthenticateStorageDAO.php
+++ b/module/EyeChart/src/DAO/Authenticate/AuthenticateStorageDAO.php
@@ -37,9 +37,6 @@ final class AuthenticateStorageDAO extends AbstractDAO implements StorageInterfa
     /** @var SessionEntity */
     private $sessionEntity;
 
-    /** @var mixed[]  */
-    private $existingStorage = [];
-
     /**
      * AuthenticateStorageService constructor.
      * @param Adapter $adapter
@@ -54,16 +51,17 @@ final class AuthenticateStorageDAO extends AbstractDAO implements StorageInterfa
     }
 
     /**
-     * Returns true if and only if storage is empty
+     * Returns true if a session record exists
      *
      * @return bool
-     * @deprecated
      */
     public function isEmpty(): bool
     {
-        $this->existingStorage = $this->read();
-
-        return empty($this->existingStorage);
+        try {
+            return empty($this->read());
+        } catch (MissingSessionException $exception) {
+            return false;
+        }
     }
 
     /**
@@ -144,18 +142,14 @@ final class AuthenticateStorageDAO extends AbstractDAO implements StorageInterfa
         }
 
         $delete = $this->sql->delete();
-
         $delete->from(SessionMapper::TABLE);
 
         $where = new Where();
-
         $where->equalTo(SessionMapper::TOKEN, $this->sessionEntity->getToken());
 
         $delete->where($where);
 
-        $statement = $this->sql->prepareStatementForSqlObject($delete);
-
-        $result = $statement->execute();
+        $result = parent::executeStatement($delete);
 
         return $result->isQueryResult();
     }
@@ -178,9 +172,7 @@ final class AuthenticateStorageDAO extends AbstractDAO implements StorageInterfa
 
         $insert->into(SessionMapper::TABLE);
 
-        $statement = $this->sql->prepareStatementForSqlObject($insert);
-
-        $result = $statement->execute();
+        $result = parent::executeStatement($insert);
 
         return $result->isQueryResult();
     }
@@ -211,15 +203,6 @@ final class AuthenticateStorageDAO extends AbstractDAO implements StorageInterfa
      * @return mixed[]
      * @deprecated
      */
-    public function getEmployeeInformation(): array
-    {
-        return $this->getUserStorage();
-    }
-
-    /**
-     * @return mixed[]
-     * @deprecated
-     */
     public function getUserStorage(): array
     {
         $userSession = $this->read();
@@ -229,14 +212,6 @@ final class AuthenticateStorageDAO extends AbstractDAO implements StorageInterfa
         }
 
         return [];
-    }
-
-    /**
-     * @return int
-     */
-    public function getSessionLifeTime(): int
-    {
-        return $this->sessionEntity->getLifetime();
     }
 
     /**
@@ -259,9 +234,7 @@ final class AuthenticateStorageDAO extends AbstractDAO implements StorageInterfa
 
         $update->where($where);
 
-        $statement = $this->sql->prepareStatementForSqlObject($update);
-
-        $result = $statement->execute();
+        $result = parent::executeStatement($update);
 
         return $result->isQueryResult();
     }

--- a/module/EyeChart/src/DAO/Authenticate/AuthenticateStorageDAO.php
+++ b/module/EyeChart/src/DAO/Authenticate/AuthenticateStorageDAO.php
@@ -233,7 +233,6 @@ final class AuthenticateStorageDAO extends AbstractDAO implements StorageInterfa
 
     /**
      * @return int
-     * @deprecated
      */
     public function getSessionLifeTime(): int
     {

--- a/module/EyeChart/src/Entity/AuthenticateEntity.php
+++ b/module/EyeChart/src/Entity/AuthenticateEntity.php
@@ -147,6 +147,8 @@ class AuthenticateEntity extends AbstractEntity
      */
     public function addMessage(string $message): void
     {
+        Assertion::notBlank($message, 'Message may not be blank');
+
         $this->messages[] = $message;
     }
 }

--- a/module/EyeChart/src/Entity/SessionEntity.php
+++ b/module/EyeChart/src/Entity/SessionEntity.php
@@ -17,38 +17,57 @@ use Assert\Assertion;
  */
 class SessionEntity extends AbstractEntity
 {
-    /** @var string */
-    protected $id = '';
-
-    /** @var string */
-    protected $name = '';
+    /** @var string  */
+    protected $sessionId = '';
 
     /** @var int */
-    protected $lifeTime = -1;
-
-    /** @var int */
-    protected $modified = -1;
+    protected $sessionRecordId = -1;
 
     /** @var string */
-    protected $data = '';
+    protected $phpSessionId = '';
+
+    /** @var string */
+    protected $sessionUser = '';
+
+    /** @var int */
+    protected $lastActive;
+
+    /** @var string */
+    protected $token = '';
 
     /**
      * @return string
      */
-    public function getId(): string
+    public function getSessionId(): string
     {
-        return $this->id;
+        return $this->sessionId;
     }
 
     /**
-     * @param string $id
+     * @param string $sessionId
+     */
+    public function setSessionId(string $sessionId)
+    {
+        Assertion::maxLength($sessionId, 32);
+
+        $this->sessionId = $sessionId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSessionRecordId(): int
+    {
+        return $this->sessionRecordId;
+    }
+
+    /**
+     * @param int $sessionRecordId
      * @return SessionEntity
      */
-    public function setId(string $id): SessionEntity
+    public function setSessionRecordId(int $sessionRecordId): SessionEntity
     {
-        Assertion::maxLength($id, 32);
-
-        $this->id = $id;
+        $this->sessionRecordId = $sessionRecordId;
 
         return $this;
     }
@@ -56,58 +75,20 @@ class SessionEntity extends AbstractEntity
     /**
      * @return string
      */
-    public function getName(): string
+    public function getPhpSessionId(): string
     {
-        return $this->name;
+        return $this->phpSessionId;
     }
 
     /**
      * @param string $name
      * @return SessionEntity
      */
-    public function setName(string $name): SessionEntity
+    public function setPhpSessionId(string $name): SessionEntity
     {
         Assertion::maxLength($name, 32);
 
-        $this->name = $name;
-
-        return $this;
-    }
-
-    /**
-     * @return int
-     */
-    public function getLifeTime(): int
-    {
-        return $this->lifeTime;
-    }
-
-    /**
-     * @param int $lifeTime
-     * @return SessionEntity
-     */
-    public function setLifeTime(int $lifeTime): SessionEntity
-    {
-        $this->lifeTime = $lifeTime;
-
-        return $this;
-    }
-
-    /**
-     * @return int
-     */
-    public function getModified(): int
-    {
-        return $this->modified;
-    }
-
-    /**
-     * @param int $modified
-     * @return SessionEntity
-     */
-    public function setModified(int $modified): SessionEntity
-    {
-        $this->modified = $modified;
+        $this->phpSessionId = $name;
 
         return $this;
     }
@@ -115,18 +96,66 @@ class SessionEntity extends AbstractEntity
     /**
      * @return string
      */
-    public function getData(): string
+    public function getSessionUser(): string
     {
-        return $this->data;
+        return $this->sessionUser;
+    }
+
+    /**
+     * @param string $sessionUser
+     * @return SessionEntity
+     */
+    public function setSessionUser(string $sessionUser): SessionEntity
+    {
+        Assertion::maxLength($sessionUser, 10);
+
+        $this->sessionUser = $sessionUser;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLifetime(): int
+    {
+        return (int) ini_get('session.gc_maxlifetime');
+    }
+
+    /**
+     * @return int
+     */
+    public function getLastActive(): int
+    {
+        return $this->lastActive;
+    }
+
+    /**
+     * @param int $lastActive
+     * @return SessionEntity
+     */
+    public function setLastActive(int $lastActive): SessionEntity
+    {
+        $this->lastActive = $lastActive;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getToken(): string
+    {
+        return $this->token;
     }
 
     /**
      * @param mixed $data
      * @return SessionEntity
      */
-    public function setData(string $data): SessionEntity
+    public function setToken(string $data): SessionEntity
     {
-        $this->data = $data;
+        $this->token = $data;
 
         return $this;
     }

--- a/module/EyeChart/src/Exception/MissingSessionException.php
+++ b/module/EyeChart/src/Exception/MissingSessionException.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+/**
+ * Created by PhpStorm.
+ * Author: Joshua M Pacheco <joshua.pacheco@gmail.com>
+ * Date: 11/18/2017
+ * (c) 2017
+ */
+
+namespace EyeChart\Exception;
+
+use EyeChart\Entity\EntityInterface;
+use EyeChart\Entity\SessionEntity;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Class MissingSessionException
+ * @package EyeChart\Exception
+ */
+class MissingSessionException extends RuntimeException
+{
+    protected $message = 'Failed to find session record';
+
+    /**
+     * MissingSessionException constructor.
+     * @param EntityInterface|SessionEntity $sessionEntity
+     * @param string $method
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        EntityInterface $sessionEntity,
+        string $method,
+        int $code = 500,
+        Throwable $previous = null
+    ) {
+        parent::__construct(
+            "{$this->message} by token {$sessionEntity->getToken()} in {$method}",
+            $code,
+            $previous
+        );
+    }
+}

--- a/module/EyeChart/src/Mappers/AuthenticateMapper.php
+++ b/module/EyeChart/src/Mappers/AuthenticateMapper.php
@@ -26,4 +26,7 @@ final class AuthenticateMapper extends AbstractMapper
     public const MESSAGES = 'messages';
     public const IS_VALID = 'isValid';
     public const HEADER   = 'X-Authentication';
+
+    public const SESSION_EXPIRED_MESSAGE = 'Your session has expired';
+    public const SESSION_ENDED_MESSAGE   = 'Your session has ended';
 }

--- a/module/EyeChart/src/Mappers/SessionMapper.php
+++ b/module/EyeChart/src/Mappers/SessionMapper.php
@@ -24,6 +24,7 @@ final class SessionMapper extends AbstractMapper
     public const SESSION_USER      = 'SessionUser';
     public const TOKEN             = 'Token';
     public const LIFETIME          = 'Lifetime';
+    public const ACCESSED          = 'AccessTimestamp';
 
     public const MODIFIED_TIME  = 'modifiedTime';
     public const SYS_TIME       = 'systemTime';

--- a/module/EyeChart/src/Mappers/SessionMapper.php
+++ b/module/EyeChart/src/Mappers/SessionMapper.php
@@ -19,11 +19,11 @@ final class SessionMapper extends AbstractMapper
     public const TABLE  = 'session';
     public const ALIAS  = 'storage';
 
-    public const SESSION_ID   = 'SessionId';
-    public const PHP_SESS_ID  = 'PHPSessId';
-    public const MODIFIED     = 'Modified';
-    public const SESSION_USER = 'SessionUser';
-    public const LIFETIME     = 'Lifetime';
+    public const SESSION_RECORD_ID = 'SessionId';
+    public const PHP_SESSION_ID    = 'PHPSessionId';
+    public const SESSION_USER      = 'SessionUser';
+    public const TOKEN             = 'Token';
+    public const LIFETIME          = 'Lifetime';
 
     public const MODIFIED_TIME  = 'modifiedTime';
     public const SYS_TIME       = 'systemTime';

--- a/module/EyeChart/src/Model/Authenticate/AuthenticateModel.php
+++ b/module/EyeChart/src/Model/Authenticate/AuthenticateModel.php
@@ -75,4 +75,28 @@ final class AuthenticateModel
             ->setSessionUser($authenticationVO->getUsername())
             ->setLastActive(time());
     }
+
+    /**
+     * @param VOInterface|AuthenticationVO $authenticationVO
+     */
+    public function setTokenToAuthenticate(VOInterface $authenticationVO): void
+    {
+        $this->authenticateEntity->setToken($authenticationVO->getToken());
+    }
+
+    /**
+     * @param string $message
+     */
+    public function addMessage(string $message): void
+    {
+        $this->authenticateEntity->addMessage($message);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getMessages(): array
+    {
+        return $this->authenticateEntity->getMessages();
+    }
 }

--- a/module/EyeChart/src/Model/Authenticate/AuthenticateModel.php
+++ b/module/EyeChart/src/Model/Authenticate/AuthenticateModel.php
@@ -70,16 +70,9 @@ final class AuthenticateModel
      */
     public function generateSessionEntity(VOInterface $authenticationVO): SessionEntity
     {
-        return $this->sessionEntity->setToken(Uuid::uuid1()->toString())
+        return $this->sessionEntity
+            ->setToken(Uuid::uuid1()->toString())
             ->setSessionUser($authenticationVO->getUsername())
             ->setLastActive(time());
-    }
-
-    /**
-     * @return string
-     */
-    public function getToken(): string
-    {
-        return $this->authenticateEntity->getToken();
     }
 }

--- a/module/EyeChart/src/Model/Authenticate/AuthenticateModelFactory.php
+++ b/module/EyeChart/src/Model/Authenticate/AuthenticateModelFactory.php
@@ -11,6 +11,7 @@ namespace EyeChart\Model\Authenticate;
 
 use EyeChart\DAO\Authenticate\AuthenticateDAO;
 use EyeChart\Entity\AuthenticateEntity;
+use EyeChart\Entity\SessionEntity;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -27,7 +28,8 @@ final class AuthenticateModelFactory
     {
         $authenticateDAO    = $container->get(AuthenticateDAO::class);
         $authenticateEntity = $container->get(AuthenticateEntity::class);
+        $sessionEntity      = $container->get(SessionEntity::class);
 
-        return new AuthenticateModel($authenticateDAO, $authenticateEntity);
+        return new AuthenticateModel($authenticateDAO, $authenticateEntity, $sessionEntity);
     }
 }

--- a/module/EyeChart/src/Model/Authenticate/AuthenticateStorageModel.php
+++ b/module/EyeChart/src/Model/Authenticate/AuthenticateStorageModel.php
@@ -87,11 +87,9 @@ final class AuthenticateStorageModel implements StorageInterface
      * @param VOInterface|AuthenticationVO $authenticationVO
      * @return bool
      */
-    public function prune(VOInterface $authenticationVO): bool
+    public function clearSessionRecord(VOInterface $authenticationVO): bool
     {
-        $this->authenticateEntity->setToken($authenticationVO->getToken());
-
-        return $this->authenticateStorageDao->prune($this->authenticateEntity);
+        return $this->authenticateStorageDao->clearSessionRecord($authenticationVO);
     }
 
     /**
@@ -121,7 +119,7 @@ final class AuthenticateStorageModel implements StorageInterface
         $hasExpired = $this->hasTokenExpired($employeeInformation);
 
         if ($hasExpired === true) {
-            $this->prune(); // TODO This requires a vo passed to it.  Resolve with issue #2
+            $this->clearSessionRecord(); // TODO This requires a vo passed to it.  Resolve with issue #2
             $this->authenticateEntity->setIsValid(false);
 
             return;

--- a/module/EyeChart/src/Model/Authenticate/AuthenticateStorageModel.php
+++ b/module/EyeChart/src/Model/Authenticate/AuthenticateStorageModel.php
@@ -112,14 +112,17 @@ final class AuthenticateStorageModel implements StorageInterface
         return $storageData[$this->authenticateEntity->getToken()];
     }
 
-    public function checkSessionStatus(): void
+    /**
+     * @param VOInterface $vo
+     */
+    public function checkSessionStatus(VOInterface $vo): void
     {
         $employeeInformation = $this->getEmployeeInformation();
 
         $hasExpired = $this->hasTokenExpired($employeeInformation);
 
         if ($hasExpired === true) {
-            $this->clearSessionRecord(); // TODO This requires a vo passed to it.  Resolve with issue #2
+            $this->clearSessionRecord($vo);
             $this->authenticateEntity->setIsValid(false);
 
             return;

--- a/module/EyeChart/src/Model/Authenticate/AuthenticateStorageModel.php
+++ b/module/EyeChart/src/Model/Authenticate/AuthenticateStorageModel.php
@@ -168,7 +168,7 @@ final class AuthenticateStorageModel implements StorageInterface
             throw new SettingNotFoundException("Key 'activeSessionCheck' was not found, check config");
         }
 
-        return $this->environment->get('timeoutWarningThreshold');
+        return $this->environment->get('activeSessionCheck');
     }
 
     /**

--- a/module/EyeChart/src/Model/Authenticate/AuthenticateStorageModel.php
+++ b/module/EyeChart/src/Model/Authenticate/AuthenticateStorageModel.php
@@ -13,6 +13,7 @@ use Assert\Assertion;
 use EyeChart\DAO\Authenticate\AuthenticateStorageDAO;
 use EyeChart\Entity\AuthenticateEntity;
 use EyeChart\Entity\EntityInterface;
+use EyeChart\Entity\SessionEntity;
 use EyeChart\Exception\SettingNotFoundException;
 use EyeChart\Mappers\SessionMapper;
 use EyeChart\VO\AuthenticationVO;
@@ -69,15 +70,12 @@ final class AuthenticateStorageModel implements StorageInterface
     }
 
     /**
-     * @param mixed[] $storage
+     * @param SessionEntity[] $storage
      * @return bool
      */
     public function write($storage): bool
     {
-        $userData                          = $this->authenticateStorageDao->write($storage);
-        $userData[SessionMapper::MODIFIED] = time();
-
-        return $userData;
+        return $this->authenticateStorageDao->write($storage);
     }
 
     public function clear(): void

--- a/module/EyeChart/src/Model/Authenticate/AuthenticateStorageModelFactory.php
+++ b/module/EyeChart/src/Model/Authenticate/AuthenticateStorageModelFactory.php
@@ -11,6 +11,7 @@ namespace EyeChart\Model\Authenticate;
 
 use EyeChart\DAO\Authenticate\AuthenticateStorageDAO;
 use EyeChart\Entity\AuthenticateEntity;
+use EyeChart\Entity\SessionEntity;
 use Psr\Container\ContainerInterface;
 use Zend\Config\Config;
 
@@ -28,12 +29,14 @@ final class AuthenticateStorageModelFactory
     {
         $authenticateStorageDAO = $container->get(AuthenticateStorageDAO::class);
         $authenticateEntity     = $container->get(AuthenticateEntity::class);
+        $sessionEntity          = $container->get(SessionEntity::class);
         $config                 = new Config($container->get('Config'));
         $environments           = $config->get('environments');
 
         return new AuthenticateStorageModel(
             $authenticateStorageDAO,
             $authenticateEntity,
+            $sessionEntity,
             $environments
         );
     }

--- a/module/EyeChart/src/Model/Authenticate/AuthenticateStorageModelFactory.php
+++ b/module/EyeChart/src/Model/Authenticate/AuthenticateStorageModelFactory.php
@@ -27,17 +27,13 @@ final class AuthenticateStorageModelFactory
      */
     public function __invoke(ContainerInterface $container): AuthenticateStorageModel
     {
-        $authenticateStorageDAO = $container->get(AuthenticateStorageDAO::class);
-        $authenticateEntity     = $container->get(AuthenticateEntity::class);
-        $sessionEntity          = $container->get(SessionEntity::class);
-        $config                 = new Config($container->get('Config'));
-        $environments           = $config->get('environments');
+        $config = new Config($container->get('Config'));
 
         return new AuthenticateStorageModel(
-            $authenticateStorageDAO,
-            $authenticateEntity,
-            $sessionEntity,
-            $environments
+            $container->get(AuthenticateStorageDAO::class),
+            $container->get(AuthenticateEntity::class),
+            $container->get(SessionEntity::class),
+            $config->get('environment')
         );
     }
 }

--- a/module/EyeChart/src/Repository/Authentication/AuthenticationRepository.php
+++ b/module/EyeChart/src/Repository/Authentication/AuthenticationRepository.php
@@ -144,19 +144,18 @@ final class AuthenticationRepository
 
     /**
      * @param VOInterface|AuthenticationVO $authenticationVO
-     * @return void
+     * @return string
      */
-    public function login(VOInterface $authenticationVO): void
+    public function login(VOInterface $authenticationVO): string
     {
         $this->authenticateModel->checkCredentials($authenticationVO);
 
-        $employeeEntity = $this->employeeModel->getEmployeeRecordByUserId($authenticationVO->getUsername());
+        $sessionEntity = $this->authenticateModel->generateSessionEntity($authenticationVO);
 
-        $storageRecord  = $this->authenticateModel->assembleStorageRecord($employeeEntity);
+        $this->authenticateStorageModel->write([ $sessionEntity ]);
+        $this->zendAuthentication->setStorage($this->authenticateStorageModel);
 
-        // TODO Resolve this with issue #2
-        //$this->authenticateStorageModel->write($storageRecord);
-        //$this->zendAuthentication->setStorage($this->authenticateStorageModel);
+        return $sessionEntity->getToken();
     }
 
     /**
@@ -176,13 +175,5 @@ final class AuthenticationRepository
     {
         // Stub TODO Resolve this with issue #2
         return [];
-    }
-
-    /**
-     * @return string
-     */
-    public function getToken(): string
-    {
-        return $this->authenticateModel->getToken();
     }
 }

--- a/module/EyeChart/src/Repository/Authentication/AuthenticationRepository.php
+++ b/module/EyeChart/src/Repository/Authentication/AuthenticationRepository.php
@@ -135,9 +135,12 @@ final class AuthenticationRepository
         return $result->isValid();
     }
 
-    public function checkSessionStatus(): void
+    /**
+     * @param VOInterface $vo
+     */
+    public function checkSessionStatus(VOInterface $vo): void
     {
-        $this->authenticateStorageModel->checkSessionStatus();
+        $this->authenticateStorageModel->checkSessionStatus($vo);
     }
 
     /**

--- a/module/EyeChart/src/Repository/Authentication/AuthenticationRepository.php
+++ b/module/EyeChart/src/Repository/Authentication/AuthenticationRepository.php
@@ -16,7 +16,6 @@ use EyeChart\Model\Authenticate\AuthenticateStorageModel;
 use EyeChart\Model\Employee\EmployeeModel;
 use EyeChart\Service\Authenticate\AuthenticateAdapter;
 use EyeChart\VO\AuthenticationVO;
-use EyeChart\VO\TokenVO;
 use EyeChart\VO\VOInterface;
 use Zend\Authentication\AuthenticationService as ZendAuthentication;
 use Zend\Authentication\AuthenticationServiceInterface;
@@ -110,14 +109,6 @@ final class AuthenticationRepository
     }
 
     /**
-     * @return mixed[]
-     */
-    public function getEmployeeInformation(): array
-    {
-        return $this->authenticateStorageModel->getEmployeeInformation();
-    }
-
-    /**
      * @param VOInterface $vo
      * @return bool
      */
@@ -171,21 +162,11 @@ final class AuthenticationRepository
     }
 
     /**
-     * @param TokenVO $tokenVO
+     * @param VOInterface $tokenVO
      * @return array[]
      */
-    public function getUserSessionByToken(TokenVO $tokenVO): array
+    public function getUserSessionStatus(VOInterface $tokenVO): array
     {
-        return $this->authenticateStorageModel->getUserSessionByToken($tokenVO);
-    }
-
-    /**
-     * @param VOInterface|TokenVO $tokenVO
-     * @return array
-     */
-    public function getTokenSession(VOInterface $tokenVO): array
-    {
-        // Stub TODO Resolve this with issue #2
-        return [];
+        return $this->authenticateStorageModel->getUserSessionStatus($tokenVO);
     }
 }

--- a/module/EyeChart/src/Service/Authenticate/AuthenticateAdapter.php
+++ b/module/EyeChart/src/Service/Authenticate/AuthenticateAdapter.php
@@ -66,8 +66,8 @@ final class AuthenticateAdapter implements AdapterInterface
         $this->sessionManager->start();
 
         $this->sessionEntity = $sessionEntity;
-        $this->sessionEntity->setId($this->sessionManager->getId());
-        $this->sessionEntity->setName($this->sessionManager->getName());
+        $this->sessionEntity->setSessionId($this->sessionManager->getId());
+        $this->sessionEntity->setPhpSessionId($this->sessionManager->getName());
 
         $this->authenticateEntity     = $authenticateEntity;
         $this->authenticateDao        = $authenticateDao;
@@ -85,7 +85,7 @@ final class AuthenticateAdapter implements AdapterInterface
     {
         $this->sessionStorage = $this->authenticateStorageDao->read();
 
-        if (array_key_exists($this->sessionEntity->getId(), $this->sessionStorage) === false) {
+        if (array_key_exists($this->sessionEntity->getSessionRecordId(), $this->sessionStorage) === false) {
             return new Result(
                 Result::FAILURE_IDENTITY_AMBIGUOUS,
                 AuthenticateMapper::TOKEN,
@@ -93,7 +93,7 @@ final class AuthenticateAdapter implements AdapterInterface
             );
         }
 
-        $storage = $this->sessionStorage[$this->sessionEntity->getId()];
+        $storage = $this->sessionStorage[$this->sessionEntity->getSessionRecordId()];
 
         if (array_key_exists($this->authenticateEntity->getToken(), $storage) === false) {
             return new Result(

--- a/module/EyeChart/src/Service/Authenticate/AuthenticateAdapterFactory.php
+++ b/module/EyeChart/src/Service/Authenticate/AuthenticateAdapterFactory.php
@@ -31,14 +31,12 @@ final class AuthenticateAdapterFactory
      */
     public function __invoke(ContainerInterface $controllers): AuthenticateAdapter
     {
-        $adapter = new AuthenticateAdapter(
+        return new AuthenticateAdapter(
             $controllers->get(SessionManager::class),
             $controllers->get(SessionEntity::class),
             $controllers->get(AuthenticateEntity::class),
             $controllers->get(AuthenticateDAO::class),
             $controllers->get(AuthenticateStorageDAO::class)
         );
-
-        return $adapter;
     }
 }

--- a/module/EyeChart/src/Service/Authenticate/AuthenticateListener.php
+++ b/module/EyeChart/src/Service/Authenticate/AuthenticateListener.php
@@ -26,24 +26,16 @@ use EyeChart\Exception\UnauthorizedException;
 final class AuthenticateListener implements ListenerAggregateInterface
 {
 
-    /**
-     * @var callable[]
-     */
+    /** @var callable[] */
     private $listeners = [];
 
-    /**
-     * @var AuthenticateService
-     */
+    /** @var AuthenticateService */
     private $authenticateService;
 
-    /**
-     *  @var AuthenticateEntity
-     */
+    /** @var AuthenticateEntity */
     private $authenticateEntity;
 
-    /**
-     * @var Config
-     */
+    /** @var Config */
     private $config;
 
     /**
@@ -51,12 +43,12 @@ final class AuthenticateListener implements ListenerAggregateInterface
      *
      * @param AuthenticateService $authenticateService
      * @param AuthenticateEntity  $authenticateEntity
-     * @param Config              $config
+     * @param Config $config
      */
     public function __construct(
         AuthenticateService $authenticateService,
         AuthenticateEntity  $authenticateEntity,
-        Config              $config
+        Config $config
     ) {
         $this->authenticateService = $authenticateService;
         $this->authenticateEntity  = $authenticateEntity;

--- a/module/EyeChart/src/Service/Authenticate/AuthenticateListener.php
+++ b/module/EyeChart/src/Service/Authenticate/AuthenticateListener.php
@@ -11,6 +11,7 @@ namespace EyeChart\Service\Authenticate;
 
 use EyeChart\Entity\AuthenticateEntity;
 use EyeChart\Mappers\AuthenticateMapper;
+use EyeChart\VO\AuthenticationVO;
 use Zend\EventManager\ListenerAggregateInterface;
 use Zend\EventManager\EventManagerInterface;
 use Zend\Config\Config;
@@ -160,9 +161,9 @@ final class AuthenticateListener implements ListenerAggregateInterface
         }
 
         if (array_key_exists(AuthenticateMapper::HEADER, $headers)) {
-            $this->authenticateEntity->setToken($headers[AuthenticateMapper::HEADER]);
+            $authenticationVO = AuthenticationVO::build()->setToken($headers[AuthenticateMapper::HEADER]);
 
-            $this->authenticateEntity->setIsValid($this->authenticateService->authenticateUser());
+            $this->authenticateEntity->setIsValid($this->authenticateService->authenticateUser($authenticationVO));
 
             $this->authenticateService->checkSessionStatus();
 

--- a/module/EyeChart/src/Service/Authenticate/AuthenticateListener.php
+++ b/module/EyeChart/src/Service/Authenticate/AuthenticateListener.php
@@ -165,7 +165,7 @@ final class AuthenticateListener implements ListenerAggregateInterface
 
             $this->authenticateEntity->setIsValid($this->authenticateService->authenticateUser($authenticationVO));
 
-            $this->authenticateService->checkSessionStatus();
+            $this->authenticateService->checkSessionStatus($authenticationVO);
 
             if ($this->authenticateEntity->getIsValid() === true) {
                 return;

--- a/module/EyeChart/src/Service/Authenticate/AuthenticateListenerFactory.php
+++ b/module/EyeChart/src/Service/Authenticate/AuthenticateListenerFactory.php
@@ -28,11 +28,10 @@ final class AuthenticateListenerFactory
      */
     public function __invoke(ContainerInterface $container): AuthenticateListener
     {
-        $authenticateService = $container->get(AuthenticateService::class);
-        $authenticateEntity  = $container->get(AuthenticateEntity::class);
-
-        $config = new Config($container->get('config'));
-
-        return new AuthenticateListener($authenticateService, $authenticateEntity, $config);
+        return new AuthenticateListener(
+            $container->get(AuthenticateService::class),
+            $container->get(AuthenticateEntity::class),
+            new Config($container->get('config'))
+        );
     }
 }

--- a/module/EyeChart/src/Service/Authenticate/AuthenticateService.php
+++ b/module/EyeChart/src/Service/Authenticate/AuthenticateService.php
@@ -56,9 +56,12 @@ final class AuthenticateService
         return $this->authenticationRepository->authenticateUser($vo);
     }
 
-    public function checkSessionStatus(): void
+    /**
+     * @param VOInterface $vo
+     */
+    public function checkSessionStatus(VOInterface $vo): void
     {
-        $this->authenticationRepository->checkSessionStatus();
+        $this->authenticationRepository->checkSessionStatus($vo);
     }
 
     /**

--- a/module/EyeChart/src/Service/Authenticate/AuthenticateService.php
+++ b/module/EyeChart/src/Service/Authenticate/AuthenticateService.php
@@ -48,11 +48,12 @@ final class AuthenticateService
     }
 
     /**
+     * @param VOInterface $vo
      * @return bool
      */
-    public function authenticateUser(): bool
+    public function authenticateUser(VOInterface $vo): bool
     {
-        return $this->authenticationRepository->authenticateUser();
+        return $this->authenticationRepository->authenticateUser($vo);
     }
 
     public function checkSessionStatus(): void

--- a/module/EyeChart/src/Service/Authenticate/AuthenticateService.php
+++ b/module/EyeChart/src/Service/Authenticate/AuthenticateService.php
@@ -40,14 +40,6 @@ final class AuthenticateService
     }
 
     /**
-     * @return mixed[]
-     */
-    public function getUserData(): array
-    {
-        return $this->authenticationRepository->getEmployeeInformation();
-    }
-
-    /**
      * @param VOInterface $vo
      * @return bool
      */

--- a/module/EyeChart/src/Service/Authenticate/AuthenticateService.php
+++ b/module/EyeChart/src/Service/Authenticate/AuthenticateService.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace EyeChart\Service\Authenticate;
 
-use Assert\Assertion;
 use EyeChart\Repository\Authentication\AuthenticationRepository;
 use EyeChart\VO\VOInterface;
 use Zend\Authentication\AuthenticationService as ZendAuthentication;
@@ -67,13 +66,7 @@ final class AuthenticateService
      */
     public function login(VOInterface $authenticationVO): string
     {
-        $this->authenticationRepository->login($authenticationVO);
-
-        $token = $this->authenticationRepository->getToken();
-
-        Assertion::length($token, 36, "Invalid token was generated.");
-
-        return $token;
+        return $this->authenticationRepository->login($authenticationVO);
     }
 
     /**

--- a/module/EyeChart/src/Service/Authenticate/AuthenticateServiceFactory.php
+++ b/module/EyeChart/src/Service/Authenticate/AuthenticateServiceFactory.php
@@ -24,17 +24,13 @@ class AuthenticateServiceFactory
      * Create and return AuthenticateService
      *
      * @param ContainerInterface $container
-     *
      * @return \EyeChart\Service\Authenticate\AuthenticateService
      */
     public function __invoke(ContainerInterface $container): AuthenticateService
     {
-        $authenticationRepository = $container->get(AuthenticationRepository::class);
-        $zendAuthentication       = new ZendAuthentication();
-
         return new AuthenticateService(
-            $authenticationRepository,
-            $zendAuthentication
+            $container->get(AuthenticationRepository::class),
+            new ZendAuthentication()
         );
     }
 }

--- a/module/EyeChart/src/Service/Authenticate/AuthenticateStorageService.php
+++ b/module/EyeChart/src/Service/Authenticate/AuthenticateStorageService.php
@@ -63,15 +63,6 @@ final class AuthenticateStorageService implements StorageInterface
     }
 
     /**
-     * @param VOInterface $vo
-     * @return bool
-     */
-    public function prune(VOInterface $vo): bool
-    {
-        return $this->authenticationRepository->prune($vo);
-    }
-
-    /**
      * @return mixed[]
      */
     public function getEmployeeInformation()

--- a/module/EyeChart/src/Service/Authenticate/AuthenticateStorageService.php
+++ b/module/EyeChart/src/Service/Authenticate/AuthenticateStorageService.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace EyeChart\Service\Authenticate;
 
+use EyeChart\Entity\SessionEntity;
 use EyeChart\Repository\Authentication\AuthenticationRepository;
-use EyeChart\VO\TokenVO;
 use EyeChart\VO\VOInterface;
 use Zend\Authentication\Storage\StorageInterface;
 
@@ -49,12 +49,12 @@ final class AuthenticateStorageService implements StorageInterface
     }
 
     /**
-     * @param mixed[] $storage
+     * @param SessionEntity[] $sessionEntity
      * @return bool
      */
-    public function write($storage): bool
+    public function write($sessionEntity): bool
     {
-        return $this->authenticationRepository->write($storage);
+        return $this->authenticationRepository->write($sessionEntity);
     }
 
     public function clear(): void
@@ -63,19 +63,11 @@ final class AuthenticateStorageService implements StorageInterface
     }
 
     /**
-     * @return mixed[]
-     */
-    public function getEmployeeInformation()
-    {
-        return $this->authenticationRepository->getEmployeeInformation();
-    }
-
-    /**
-     * @param VOInterface|TokenVO $tokenVO
+     * @param VOInterface $tokenVO
      * @return array
      */
-    public function getTokenSession(TokenVO $tokenVO): array
+    public function getUserSessionByToken(VOInterface $tokenVO): array
     {
-        return $this->authenticationRepository->getTokenSession($tokenVO);
+        return $this->authenticationRepository->getUserSessionStatus($tokenVO);
     }
 }

--- a/module/EyeChart/src/Service/Authenticate/AuthenticateStorageServiceFactory.php
+++ b/module/EyeChart/src/Service/Authenticate/AuthenticateStorageServiceFactory.php
@@ -24,8 +24,8 @@ final class AuthenticateStorageServiceFactory
      */
     public function __invoke(ContainerInterface $controllers): AuthenticateStorageService
     {
-        $authenticationRepository = $controllers->get(AuthenticationRepository::class);
-
-        return new AuthenticateStorageService($authenticationRepository);
+        return new AuthenticateStorageService(
+            $controllers->get(AuthenticationRepository::class)
+        );
     }
 }


### PR DESCRIPTION
Closes #2 

The goal of this was to refactor out the pre-existing complexity of session user data storage.  While I still make use of the framework adapter, my goal here was to create simply a session record with a unique token.. end of story.  I did not see the need to store anything more specific at this point, especially having a column in the record that held json mongo'ish horrors.  Later down the road, the token and the user name can be used to retrieve more information about a user as required.

In the end, this controller is meant to simply 'ping' the session table, find out when it was last altered and return an informational payload.